### PR TITLE
Chrome driver is executed in headless mode if the user is jenkins

### DIFF
--- a/tests/qctools.py
+++ b/tests/qctools.py
@@ -5,7 +5,7 @@ from selenium.webdriver.common.by import By
 
 def set_chrome_options():
     chrome_options = Options()
-    if os.environ.get('HOST_NAME') and os.environ['HOST_NAME'].startswith("travis"):
+    if os.environ.get('USER') and os.environ['USER']=='jenkins':
         chrome_options.add_argument("--headless")
 
     return chrome_options


### PR DESCRIPTION
Attempting to get Jenkins to be able to drive Chrome in headless mode similar to how it was done with Travis-CI.