### PR TITLE
Made qctools return an appropriate Chrome driver depending on the env

### DIFF
--- a/tests/qctools.py
+++ b/tests/qctools.py
@@ -2,13 +2,19 @@ import os
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
+from selenium import webdriver
 
-def set_chrome_options():
-    chrome_options = Options()
+
+def get_chrome_driver():
+    chrome_driver_path = "/usr/local/bin/chromedriver"
     if os.environ.get('USER') and os.environ['USER']=='jenkins':
+        chrome_options = Options()
         chrome_options.add_argument("--headless")
-
-    return chrome_options
+	return webdriver.Chrome(options=chrome_options,executable_path=chrome_driver_path)
+    else:
+	return webdriver.Chrome()
+    
+    
 
 def wait_and_click_button(driver,target_by,target_keyword):
     #works with a button usually searched by CSS_SELECTOR

--- a/tests/test_computeSeisTech_Psha_Frontend.py
+++ b/tests/test_computeSeisTech_Psha_Frontend.py
@@ -14,19 +14,13 @@ from selenium.webdriver.chrome.options import Options
 import glob
 import os
 
-from qctools import set_chrome_options, wait_and_click_button, wait_and_click, clear_input_field, check_error_display
+from qctools import get_chrome_driver, wait_and_click_button, wait_and_click, clear_input_field, check_error_display
 
-chrome_driver_path = "/usr/local/bin/chromedriver"
 
-chrome_options = set_chrome_options()
 
 class TestComputeSeisTech_Psha_Frontend():
   def setup_method(self, method):
-    if os.path.exists(chrome_driver_path):
-      self.driver = webdriver.Chrome(options=chrome_options,executable_path=chrome_driver_path)
-    else:
-      self.driver = webdriver.Chrome(options=chrome_options) 
-     
+    self.driver = get_chrome_driver() 
     self.vars = {}
     try:
       self.deploy_name=os.environ['DEPLOY_NAME']


### PR DESCRIPTION
This should the issue with Jenkins ec2 not being able to find the path to chromedriver, and should also support a selenium test triggered locally (running actual Chrome not in headless mode)
