### PR TITLE
Fix the Download URL & Disable GMS Tab for Project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## January 18, 2021
+
+## Fix the Download URL & Disable GMS Tab - ([PR #32](https://github.com/ucgmsim/seistech_psha_frontend/pull/32))
+
+- Now the URL does not include extra unnecessary character in the end.
+- Disabled the GMS tab for now as it does not contain anything but saying "GMS is coming!"
+
 ## January 15, 2021
 
 ### EC2 Docker setup - ([PR #30](https://github.com/ucgmsim/seistech_psha_frontend/pull/30))

--- a/frontend/src/components/common/DownloadButton.js
+++ b/frontend/src/components/common/DownloadButton.js
@@ -41,7 +41,7 @@ const DownloadButton = ({
     }
 
     // remove the last character which is an extra &
-    queryString.slice(0, -1);
+    queryString = queryString.slice(0, -1);
 
     axios({
       url: CORE_API_BASE_URL + downloadURL + queryString,

--- a/frontend/src/views/Project.js
+++ b/frontend/src/views/Project.js
@@ -45,7 +45,7 @@ const Project = () => {
         <Tab
           eventKey="gms"
           title="GMS"
-          disabled={validateTab()}
+          disabled
           tabClassName="gms-tab"
         >
           <TwoColumnView cpanel={GmsForm} viewer={GmsViewer} />


### PR DESCRIPTION
# Fix the Download URL & Disable GMS Tab for Project

Remove the last character properly and disabled the GMS tab for the Project page as it doesn't look go to leave it available but it says "Coming soon"