### PR TITLE
Fix the Project's UHS plots and update Project/Hazard's UHS plotly.js label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## January 19, 2021
+
+### Fix the Project's UHS plots and update Project/Hazard's UHS plotly.js label - ([PR #34](https://github.com/ucgmsim/seistech_psha_frontend/pull/34))
+
+- Fix the plots so now Project's UHS only plot with selected RPs instead of every possible rate.
+- Label now contains both RP and Rate information.
+
 ## January 18, 2021
 
-## Fix the Download URL & Disable GMS Tab - ([PR #32](https://github.com/ucgmsim/seistech_psha_frontend/pull/32))
+### Fix the Download URL & Disable GMS Tab - ([PR #32](https://github.com/ucgmsim/seistech_psha_frontend/pull/32))
 
 - Now the URL does not include extra unnecessary character in the end.
 - Disabled the GMS tab for now as it does not contain anything but saying "GMS is coming!"

--- a/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Hazard/SeismicHazard/HazardViewerUHS.js
@@ -122,7 +122,7 @@ const HazardViewerUhs = () => {
             .then(handleErrors)
             .then(async (uhsResponse) => {
               const responseData = await uhsResponse.json();
-              setUHSData(responseData);
+              setUHSData(responseData["uhs_df"]);
               setDownloadUHSToken(responseData["download_token"]);
 
               let nzCodeQueryString = `?ensemble_id=${selectedEnsemble}&station=${station}&exceedances=${getExceedances().join(

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -61,6 +61,26 @@ const HazardViewerUhs = () => {
     return tempArray;
   };
 
+  /* 
+    Filtering the UHSData based on the selected RPs
+    First of all, we are going to loop through the object.
+    Then check the key of the object is in the selected RP list (E.g., 72, 475, 2475)
+    If it eixts, we create another object with the key that are in he selectedRP list and the value is from UHSData
+
+    Simply, if UHSData object is like {A: {...}, B: {...}, C: {...}} and selectedRP is [A, C] 
+    Then we create a new object that will have a key of A and C only, => {A: {...}, C: {...}} as users only chose A and C so no need to display/plot for B.
+  */
+  const filterUHSData = (UHSData, selectedRP) => {
+    const filtered = Object.keys(UHSData)
+      .filter((key) => selectedRP.includes(1 / Number(key)))
+      .reduce((obj, key) => {
+        obj[key] = UHSData[key];
+        return obj;
+      }, {});
+
+    return filtered;
+  };
+
   useEffect(() => {
     const abortController = new AbortController();
     const signal = abortController.signal;
@@ -78,8 +98,6 @@ const HazardViewerUhs = () => {
             projectLocationCode[projectLocation]
           }_${projectVS30}&rp=${getSelectedRP().join(",")}`;
 
-          console.log(getSelectedRP())
-
           await fetch(
             CONSTANTS.CORE_API_BASE_URL +
               CONSTANTS.PROJECT_API_ROUTE_PROJECT_UHS_GET +
@@ -94,8 +112,12 @@ const HazardViewerUhs = () => {
             .then(handleErrors)
             .then(async (response) => {
               const responseData = await response.json();
-              setUHSData(responseData["uhs_df"]);
-              setUHSNZCodeData(responseData["nz_code_uhs_df"]);
+              setUHSData(
+                filterUHSData(responseData["uhs_df"], getSelectedRP())
+              );
+              setUHSNZCodeData(
+                filterUHSData(responseData["nz_code_uhs_df"], getSelectedRP())
+              );
               setDownloadToken(responseData["download_token"]);
               setShowSpinnerUHS(false);
               setShowPlotUHS(true);

--- a/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
+++ b/frontend/src/components/Project/SeismicHazard/HazardViewerUHS.js
@@ -78,6 +78,8 @@ const HazardViewerUhs = () => {
             projectLocationCode[projectLocation]
           }_${projectVS30}&rp=${getSelectedRP().join(",")}`;
 
+          console.log(getSelectedRP())
+
           await fetch(
             CONSTANTS.CORE_API_BASE_URL +
               CONSTANTS.PROJECT_API_ROUTE_PROJECT_UHS_GET +
@@ -92,7 +94,7 @@ const HazardViewerUhs = () => {
             .then(handleErrors)
             .then(async (response) => {
               const responseData = await response.json();
-              setUHSData(responseData);
+              setUHSData(responseData["uhs_df"]);
               setUHSNZCodeData(responseData["nz_code_uhs_df"]);
               setDownloadToken(responseData["download_token"]);
               setShowSpinnerUHS(false);

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -1,7 +1,12 @@
 import React from "react";
 import Plot from "react-plotly.js";
-import { getPlotData } from "utils/Utils.js";
-import { PLOT_MARGIN, PLOT_CONFIG } from "constants/Constants";
+import { getPlotData, renderSigfigs } from "utils/Utils.js";
+import {
+  PLOT_MARGIN,
+  PLOT_CONFIG,
+  APP_UI_SIGFIGS,
+  APP_UI_UHS_RATETABLE_RATE_SIGFIGS,
+} from "constants/Constants";
 import ErrorMessage from "components/common/ErrorMessage";
 
 import "assets/style/UHSPlot.css";
@@ -17,13 +22,30 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
         // Else we plot
       } else {
         let curPlotData = getPlotData(curData);
+        // Convert the Annual exdance reate to Return period in a string format
+        let displayRP = (1 / Number(curExcd)).toString();
         scatterObjs.push({
           x: curPlotData.index,
           y: curPlotData.values,
           type: "scatter",
           mode: "lines",
           line: { color: "black" },
-          name: `NZ Code - ${curExcd}`,
+          name:
+            // Then if the string contains `.` means it's in float/decimal that needs to display in 4SF for RP, 3SF for rate
+            // Else, print what it is as it is an integer.
+            // E.g., "14".indexOf(".") returns -1 as it does not have "." in it
+            displayRP.indexOf(".") == -1
+              ? `NZ Code - RP ${Number(displayRP)} - ${renderSigfigs(
+                  Number(1 / displayRP),
+                  APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+                )}`
+              : `NZ Code - RP ${renderSigfigs(
+                  Number(displayRP),
+                  APP_UI_SIGFIGS
+                )} - ${renderSigfigs(
+                  Number(1 / displayRP),
+                  APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+                )}`,
           visible: showNZCode,
         });
       }
@@ -32,13 +54,26 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
     // UHS scatter objs
     for (let [curExcd, curData] of Object.entries(uhsData)) {
       let curPlotData = getPlotData(curData);
+      let displayRP = (1 / Number(curExcd)).toString();
       scatterObjs.push({
         x: curPlotData.index,
         y: curPlotData.values,
         type: "scatter",
         mode: "lines",
         line: { color: "blue" },
-        name: `${curExcd}`,
+        name:
+          displayRP.indexOf(".") == -1
+            ? `RP ${Number(displayRP)} - ${renderSigfigs(
+                Number(1 / displayRP),
+                APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+              )} `
+            : `RP ${renderSigfigs(
+                1 / Number(curExcd),
+                APP_UI_SIGFIGS
+              )} - ${renderSigfigs(
+                Number(1 / displayRP),
+                APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+              )}`,
       });
     }
 

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -7,7 +7,6 @@ import ErrorMessage from "components/common/ErrorMessage";
 import "assets/style/UHSPlot.css";
 
 const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
-  console.log(extra)
   if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
     // Create NZ code UHS scatter objs
     const scatterObjs = [];

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -60,7 +60,9 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
           mode: "lines",
           line: { color: "black" },
           name: createLabel(displayRP, true),
+          text: createLabel(displayRP, true),
           visible: showNZCode,
+          hoverinfo: "text",
         });
       }
     }
@@ -76,6 +78,8 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
         mode: "lines",
         line: { color: "blue" },
         name: createLabel(displayRP),
+        text: createLabel(displayRP),
+        hoverinfo: "text",
       });
     }
 

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -7,6 +7,7 @@ import ErrorMessage from "components/common/ErrorMessage";
 import "assets/style/UHSPlot.css";
 
 const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
+  console.log(extra)
   if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
     // Create NZ code UHS scatter objs
     const scatterObjs = [];
@@ -30,7 +31,7 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
     }
 
     // UHS scatter objs
-    for (let [curExcd, curData] of Object.entries(uhsData["uhs_df"])) {
+    for (let [curExcd, curData] of Object.entries(uhsData)) {
       let curPlotData = getPlotData(curData);
       scatterObjs.push({
         x: curPlotData.index,

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -13,6 +13,37 @@ import "assets/style/UHSPlot.css";
 
 const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
   if (uhsData !== null && !uhsData.hasOwnProperty("error")) {
+    /* 
+      if the string(displayRP parameter) contains `.` means it's in float/decimal that needs to display in 4SF for RP, 3SF for rate
+      Else, print what it is as it is an integer.
+      E.g., "14".indexOf(".") returns -1 as it does not have "." in it
+
+      displayRP = Selected RPs
+      isNZCode = to check whether its for NZCode or not, default to false.
+     */
+    const createLabel = (displayRP, isNZCode = false) => {
+      let newLabel = "";
+      if (isNZCode === true) {
+        newLabel = "NZ Code - ";
+      }
+
+      if (displayRP.indexOf(".") === -1) {
+        newLabel += `RP ${Number(displayRP)} - ${renderSigfigs(
+          Number(1 / displayRP),
+          APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+        )} `;
+      } else {
+        newLabel += `RP ${renderSigfigs(
+          Number(displayRP),
+          APP_UI_SIGFIGS
+        )} - ${renderSigfigs(
+          Number(1 / displayRP),
+          APP_UI_UHS_RATETABLE_RATE_SIGFIGS
+        )}`;
+      }
+
+      return newLabel;
+    };
     // Create NZ code UHS scatter objs
     const scatterObjs = [];
     for (let [curExcd, curData] of Object.entries(nzCodeData)) {
@@ -30,22 +61,7 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
           type: "scatter",
           mode: "lines",
           line: { color: "black" },
-          name:
-            // Then if the string contains `.` means it's in float/decimal that needs to display in 4SF for RP, 3SF for rate
-            // Else, print what it is as it is an integer.
-            // E.g., "14".indexOf(".") returns -1 as it does not have "." in it
-            displayRP.indexOf(".") == -1
-              ? `NZ Code - RP ${Number(displayRP)} - ${renderSigfigs(
-                  Number(1 / displayRP),
-                  APP_UI_UHS_RATETABLE_RATE_SIGFIGS
-                )}`
-              : `NZ Code - RP ${renderSigfigs(
-                  Number(displayRP),
-                  APP_UI_SIGFIGS
-                )} - ${renderSigfigs(
-                  Number(1 / displayRP),
-                  APP_UI_UHS_RATETABLE_RATE_SIGFIGS
-                )}`,
+          name: createLabel(displayRP, true),
           visible: showNZCode,
         });
       }
@@ -61,19 +77,7 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
         type: "scatter",
         mode: "lines",
         line: { color: "blue" },
-        name:
-          displayRP.indexOf(".") == -1
-            ? `RP ${Number(displayRP)} - ${renderSigfigs(
-                Number(1 / displayRP),
-                APP_UI_UHS_RATETABLE_RATE_SIGFIGS
-              )} `
-            : `RP ${renderSigfigs(
-                1 / Number(curExcd),
-                APP_UI_SIGFIGS
-              )} - ${renderSigfigs(
-                Number(1 / displayRP),
-                APP_UI_UHS_RATETABLE_RATE_SIGFIGS
-              )}`,
+        name: createLabel(displayRP),
       });
     }
 

--- a/frontend/src/components/common/UHS/UHSPlot.js
+++ b/frontend/src/components/common/UHS/UHSPlot.js
@@ -22,10 +22,8 @@ const UHSPlot = ({ uhsData, nzCodeData, showNZCode = true, extra }) => {
       isNZCode = to check whether its for NZCode or not, default to false.
      */
     const createLabel = (displayRP, isNZCode = false) => {
-      let newLabel = "";
-      if (isNZCode === true) {
-        newLabel = "NZ Code - ";
-      }
+      // Depends on the isNZCode status, newLabel starts with NZ Code - or an empty string
+      let newLabel = isNZCode === true ? "" : "NZ Code - ";
 
       if (displayRP.indexOf(".") === -1) {
         newLabel += `RP ${Number(displayRP)} - ${renderSigfigs(


### PR DESCRIPTION
# Fix the Project's UHS plots and update Project/Hazard's UHS plotly.js label

UHS Plotly.js plots now include both return period and exceedance rate information in a label.
Return Period is displayed in 4 SF.
Exceedance Rate is displayed in 3 SF.

## Hazard Analysis - UHS Plot

For Hazard Analysis, users put the annual exceedance rate(For now but will have two different inputs, 1. Annual exceedance rate, 2. Return Period) and it will contain `.` in input as we only accept the rate between 0 < x < 1. This case, plotly.js will use either 3SF or 4SF to their label(depends on whether its Rate or RP) to display as they are float/double.

![image](https://user-images.githubusercontent.com/7849113/104981656-e384d300-5a6d-11eb-87a4-16fed830a5d6.png)

## Project - UHS Plot

Whereas for Project, users choose from the given Return Periods and they are integer(for now).

In this case, we do not have to apply any significant figures so display an actual Return Period. But we are adding extra information in a label, Rate, so applying 3SF to the rate to follow the conventions.

![image](https://user-images.githubusercontent.com/7849113/104981718-04e5bf00-5a6e-11eb-9554-1c5a221eebf0.png)

## Fixed to display selected RPs

Also, it is now fixed to display only the selected RPs plots as we used to plot every possible rate regardless of what users chose.

![image](https://user-images.githubusercontent.com/7849113/104982162-f2b85080-5a6e-11eb-9d06-40a542abf82a.png)
![image](https://user-images.githubusercontent.com/7849113/104982180-f946c800-5a6e-11eb-8056-5a63ec234396.png)


## UHS Plotly.js label updated on hover

### What it used to look like

![Screenshot 2021-01-20 11:26:23](https://user-images.githubusercontent.com/7849113/105100841-cbb35a80-5b12-11eb-8693-3b03b4c30e7a.png)

### What it looks like now

![Screenshot 2021-01-20 10:52:42](https://user-images.githubusercontent.com/7849113/105100854-d372ff00-5b12-11eb-933d-7424ff2ce8fc.png)
