### PR TITLE
if IM does not have im with pSA, disable UHS selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## January 27, 2021
+
+### Filter UHS section based on given IM list - ([PR #38](https://github.com/ucgmsim/seistech_psha_frontend/pull/38))
+
+- If IM does not have one starts with `pSA`, the UHS section will be disabled.
+
 ## January 22, 2021
 
 ### HOTFIX - Flask-SQLAlchemy isolation level config - ([PR #37](https://github.com/ucgmsim/seistech_psha_frontend/pull/37))

--- a/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Hazard/SeismicHazard/UHSSection.js
@@ -3,7 +3,11 @@ import * as CONSTANTS from "constants/Constants";
 import { v4 as uuidv4 } from "uuid";
 import { GlobalContext } from "context";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { renderSigfigs, disableScrollOnNumInput } from "utils/Utils";
+import {
+  renderSigfigs,
+  disableScrollOnNumInput,
+  checkIMwithPSA,
+} from "utils/Utils";
 import TextField from "@material-ui/core/TextField";
 
 const UHSSection = () => {
@@ -15,6 +19,7 @@ const UHSSection = () => {
     uhsTableDeleteRow,
     showUHSNZCode,
     setShowUHSNZCode,
+    IMs,
   } = useContext(GlobalContext);
 
   const [disableButtonUHSCompute, setDisableButtonUHSCompute] = useState(true);
@@ -109,6 +114,7 @@ const UHSSection = () => {
                 ? " "
                 : "Annual Exceedance Rate must be between 0 and 1. (0 < X < 1)"
             }
+            disabled={checkIMwithPSA(IMs)}
           />
         </div>
         <div className="form-group">
@@ -145,7 +151,7 @@ const UHSSection = () => {
           id="uhs-update-plot"
           type="button"
           className="btn btn-primary mt-2"
-          disabled={disableButtonUHSCompute}
+          disabled={disableButtonUHSCompute || checkIMwithPSA(IMs)}
           onClick={() => {
             setUHSComputeClick(uuidv4());
           }}

--- a/frontend/src/components/Project/SeismicHazard/UHSSection.js
+++ b/frontend/src/components/Project/SeismicHazard/UHSSection.js
@@ -3,7 +3,7 @@ import React, { useState, useContext, useEffect, Fragment } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { GlobalContext } from "context";
 
-import { createSelectArray } from "utils/Utils";
+import { createSelectArray, checkIMwithPSA } from "utils/Utils";
 
 import Select from "react-select";
 import makeAnimated from "react-select/animated";
@@ -14,6 +14,7 @@ const UHSSection = () => {
     projectSelectedUHSRP,
     setProjectSelectedUHSRP,
     setProjectUHSGetClick,
+    projectIMs,
   } = useContext(GlobalContext);
 
   const animatedComponents = makeAnimated();
@@ -57,6 +58,7 @@ const UHSSection = () => {
             onChange={(value) => setLocalRPs(value || [])}
             options={options}
             isDisabled={options.length === 0}
+            disabled={checkIMwithPSA(projectIMs)}
           />
         </div>
       </form>
@@ -66,7 +68,7 @@ const UHSSection = () => {
           id="uhs-update-plot"
           type="button"
           className="btn btn-primary mt-2"
-          disabled={localRPs.length === 0}
+          disabled={localRPs.length === 0 || checkIMwithPSA(projectIMs)}
           onClick={() => {
             getUHS();
           }}

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -86,7 +86,7 @@ export const createProjectIDArray = (options) => {
 };
 
 /*
-  Check the IM list and decide to disable UHS input field.
+  Check the IM list and decide to disable the UHS input field.
   No pSA in IM(return true), we disable the UHS
 */
 export const checkIMwithPSA = (givenIMList) => {

--- a/frontend/src/utils/Utils.js
+++ b/frontend/src/utils/Utils.js
@@ -86,6 +86,19 @@ export const createProjectIDArray = (options) => {
 };
 
 /*
+  Check the IM list and decide to disable UHS input field.
+  No pSA in IM(return true), we disable the UHS
+*/
+export const checkIMwithPSA = (givenIMList) => {
+  for (let i = 0; i < givenIMList.length; i++) {
+    if (givenIMList[i].includes("pSA")) {
+      return false;
+    }
+  }
+  return true;
+};
+
+/*
   JS version of qcore IM Sort
 */
 


### PR DESCRIPTION
# IM checker 

We now have a function that checks the IM list to see if it has `pSA`.

For instance, if the IM only returns with `PGA` that it does not have `pSA` hence we disable the UHS section.

For instance, with NZGS project ID, we only have `PGA` for IM, and for this case, we should disable the UHS.
![Screen Shot 2021-01-27 at 9 55 05 AM](https://user-images.githubusercontent.com/7849113/105904308-d9725e00-6085-11eb-9904-2d8b5fb8de9e.png)
![Screen Shot 2021-01-27 at 9 55 13 AM](https://user-images.githubusercontent.com/7849113/105904310-db3c2180-6085-11eb-8eb0-c254fdbf7c91.png)

## Filter function

This function will check the provided IM list and see if it contains `pSA`, if so it returns false as we used this function to `disabled` props by IM contains `pSA`, returning false means we will not disable it.

But if it does not have `pSA` then it returns true for a disabled prop which will be disabled.

```javascript
/*
  Check the IM list and decide to disable the UHS input field.
  No pSA in IM(return true), we disable the UHS
*/
export const checkIMwithPSA = (givenIMList) => {
  for (let i = 0; i < givenIMList.length; i++) {
    if (givenIMList[i].includes("pSA")) {
      return false;
    }
  }
  return true;
};
```
