### PR TITLE
Hotfix - null event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## February 10, 2021
+
+### HOTFIX - ([PR #43](https://github.com/ucgmsim/seistech_psha_frontend/pull/43))
+
+- `useEffect` hook only works when an object is not empty due to using `replaceAll` function.
+
 ## February 9, 2021
 
 ### GMS Viewer - ([PR #42](https://github.com/ucgmsim/seistech_psha_frontend/pull/42))

--- a/frontend/src/components/Hazard/SeismicHazard/NZS1170Section.js
+++ b/frontend/src/components/Hazard/SeismicHazard/NZS1170Section.js
@@ -59,15 +59,18 @@ const NZS1170Section = () => {
     Based on them, create an array to be used in react-select.
   */
   useEffect(() => {
-    const tempArr = [];
+    if (Object.entries(soilClass).length > 0) {
+      // Due to value.replaceAll can't be applied on null, check the object is not empty
+      const tempArr = [];
 
-    for (const [key, value] of Object.entries(soilClass)) {
-      tempArr.push({
-        value: key,
-        label: `${key} - ${value.replaceAll("_", " ")}`,
-      });
+      for (const [key, value] of Object.entries(soilClass)) {
+        tempArr.push({
+          value: key,
+          label: `${key} - ${value.replaceAll("_", " ")}`,
+        });
+      }
+      setLocalSoilClasses(tempArr);
     }
-    setLocalSoilClasses(tempArr);
   }, [soilClass]);
 
   /*

--- a/frontend/src/context/GlobalContext.js
+++ b/frontend/src/context/GlobalContext.js
@@ -53,7 +53,7 @@ export const Provider = (props) => {
 
   const [nzCodeDefaultParams, setNzCodeDefaultParams] = useState([]);
 
-  const [soilClass, setSoilClass] = useState([]);
+  const [soilClass, setSoilClass] = useState({});
 
   // Check box stats for Hazard Curve and UHS for NZCode, default is true
   const [showHazardNZCode, setShowHazardNZCode] = useState(true);


### PR DESCRIPTION
# HOTFIX - null event

Make inside `useEffect` hook to work when the `soilClass` is not an empty object.

As for loop on Object will still run regardless of the size of it and it attempts to apply `replaceAll` on null that causes an error this case.

By adding this, even CoreAPI is dead, the app will not crash. 

Ideally, we will add error handler regarding this sort of issue(e.g., CoreAPI's status, should not crash the app based on the API's status)
![image](https://user-images.githubusercontent.com/7849113/107446854-22590500-6ba4-11eb-8cd6-605fbc6c0533.png)
